### PR TITLE
Prevent NullPointerException

### DIFF
--- a/proxy-instance/src/main/java/edu/jhuapl/accumulo/proxy/ProxyBatchScanner.java
+++ b/proxy-instance/src/main/java/edu/jhuapl/accumulo/proxy/ProxyBatchScanner.java
@@ -113,6 +113,9 @@ class ProxyBatchScanner extends AbstractProxyScanner implements BatchScanner {
   }
 
   public void close() {
+    if(scannerId == null) {
+      return;
+    }
     try {
       connector.getClient().closeScanner(scannerId);
     } catch (TException e) {


### PR DESCRIPTION
If you close a batch scanner twice, a NullPointerException happens since scannerId is set to null. Checking to see if the value is already null before trying to close it again prevents this.